### PR TITLE
League positions table

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -5,7 +5,7 @@ class ParticipantsController < ApplicationController
   # GET /participants
   # GET /participants.json
   def index
-    @participants = Participant.all
+    @participants = Participant.order(score: :desc, rank: :desc)
   end
 
   # GET /participants/1

--- a/app/models/match_participation.rb
+++ b/app/models/match_participation.rb
@@ -2,7 +2,14 @@ class MatchParticipation < ApplicationRecord
   belongs_to :participant
   belongs_to :match, inverse_of: :match_participations
 
+  after_commit :update_participant_score
+
   enum color: %w{black white}
 
   validates_presence_of :color
+
+
+  def update_participant_score
+    participant.update_score
+  end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -5,4 +5,12 @@ class Participant < ApplicationRecord
   has_many :matches, through: :match_participations
   delegate :first_name, :last_name, :full_name, to: :player
   validates_presence_of :score
+
+  def update_score
+    new_score = 0
+    match_participations.each do |game|
+      new_score += game.winner ? 3 : 1
+    end
+    update score: new_score
+  end
 end

--- a/app/views/participants/index.html.slim
+++ b/app/views/participants/index.html.slim
@@ -5,6 +5,7 @@ table
     tr
       th Full Name
       th Rank
+      th Score
       th
       th
       th
@@ -14,6 +15,7 @@ table
       tr
         td = participant.full_name
         td = participant.rank
+        td = participant.score
         td = link_to 'Show', league_participant_path(@league, participant)
         td = link_to 'Edit', edit_league_participant_path(@league, participant)
         td = link_to 'Destroy', league_participant_path(@league, participant), data: { confirm: 'Are you sure?' }, method: :delete

--- a/app/views/participants/show.html.slim
+++ b/app/views/participants/show.html.slim
@@ -6,6 +6,9 @@ p
 p
   strong Rank:
   = @participant.rank
+p
+  strong Score:
+  = @participant.score
 
 => link_to 'Edit', edit_league_participant_path(@participant)
 '|

--- a/spec/factories/match_participation.rb
+++ b/spec/factories/match_participation.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     color { 'white' }
   end
 
-  trait :winner do
+  trait :won do
     winner { true }
   end
 end

--- a/spec/models/match_participation_spec.rb
+++ b/spec/models/match_participation_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe MatchParticipation, type: :model do
       subject.color = nil
       expect(subject).to be_invalid
     end
+  end
 
+  describe 'update_participant_score' do
+    it 'calls update_score on participant' do
+      allow(subject.participant).to receive(:update_score)
+      subject.update_participant_score
+      expect(subject.participant).to have_received(:update_score)
+    end
   end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -3,6 +3,29 @@ require 'rails_helper'
 RSpec.describe Participant, type: :model do
   subject { build(:participant) }
 
+  describe '#update_score' do
+    let(:won_games) { build_list(:match_participation, 3, :won) }
+    let(:lost_games) { build_list(:match_participation, 3) }
+
+    it 'adds 3 points per won game' do
+      subject.match_participations << won_games
+      subject.update_score
+      expect(subject.score).to eq(9)
+    end
+
+    it 'adds 1 point per lost game' do
+      subject.match_participations << lost_games
+      subject.update_score
+      expect(subject.score).to eq(3)
+    end
+
+    it 'counts both lost and won games' do
+      subject.match_participations << lost_games + won_games
+      subject.update_score
+      expect(subject.score).to eq(12)
+    end
+  end
+
   describe 'AR record validations' do
     it 'is valid with valid attributes' do
       expect(subject).to be_valid


### PR DESCRIPTION
This pr adds the feature of having the league positions table. The design seems to be clean since it's just the participants index sorted by score. This was implemented with a simple after commit callback on match participation, since an update on match participation can only mean that the scores need to change.